### PR TITLE
Mccalluc/details table style

### DIFF
--- a/portal/render.py
+++ b/portal/render.py
@@ -8,7 +8,7 @@ def dict_as_html(input_dict, tagtext=None):
     '''
     doc, tag, text = tagtext or Doc().tagtext()
 
-    with tag('table'):
+    with tag('table', klass='table table-bordered'):
         for key, value in input_dict.items():
             with tag('tr'):
                 with tag('td'):

--- a/portal/render.py
+++ b/portal/render.py
@@ -8,18 +8,25 @@ def dict_as_html(input_dict, tagtext=None):
     '''
     doc, tag, text = tagtext or Doc().tagtext()
 
-    with tag('table', klass='table table-bordered'):
+    def table():
+        return tag('table', klass='table table-bordered')
+    def tr():
+        return tag('tr')
+    def td():
+        return tag('td')
+
+    with table():
         for key, value in input_dict.items():
-            with tag('tr'):
-                with tag('td'):
+            with tr():
+                with td():
                     text(key)
-                with tag('td'):
+                with td():
                     if type(value) == list:
                         if any(type(i) == dict for i in value):
-                            with tag('table'):
+                            with table():
                                 for item in value:
-                                    with tag('tr'):
-                                        with tag('td'):
+                                    with tr():
+                                        with td():
                                             dict_as_html(item, (doc, tag, text))
                         else:
                             text(', '.join([str(i) for i in value]))

--- a/portal/render.py
+++ b/portal/render.py
@@ -1,9 +1,9 @@
 from yattag import Doc
 
 
-def dict_as_html(input_dict, tagtext=None):
+def object_as_html(input_object, tagtext=None):
     '''
-    Render input_dict as an html table.
+    Render input_object as an html table.
     Provide tagtext when recursing, to continue using an existing builder.
     '''
     doc, tag, text = tagtext or Doc().tagtext()
@@ -20,24 +20,24 @@ def dict_as_html(input_dict, tagtext=None):
     def td_value():
         return tag('td', klass='td-value')
 
-    with table():
-        for key, value in input_dict.items():
-            with tr():
-                with td_key():
-                    text(key)
-                with td_value():
-                    if type(value) == list:
-                        if any(type(i) == dict for i in value):
-                            with table():
-                                for item in value:
-                                    with tr():
-                                        with td_value():
-                                            dict_as_html(item, (doc, tag, text))
-                        else:
-                            text(', '.join([str(i) for i in value]))
-                    elif type(value) == dict:
-                        dict_as_html(value, (doc, tag, text))
-                    else:
-                        text(value)
+    if type(input_object) == list:
+        if all(type(i) == str for i in input_object):
+            text(', '.join([str(i) for i in input_object]))
+        else:
+            with table():
+                for item in input_object:
+                    with tr():
+                        with td_value():
+                            object_as_html(item, (doc, tag, text))
+    elif type(input_object) == dict:
+        with table():
+            for key, value in input_object.items():
+                with tr():
+                    with td_key():
+                        text(key)
+                    with td_value():
+                        object_as_html(value, (doc, tag, text))
+    else:
+        text(input_object)
 
     return doc.getvalue()

--- a/portal/render.py
+++ b/portal/render.py
@@ -9,24 +9,26 @@ def dict_as_html(input_dict, tagtext=None):
     doc, tag, text = tagtext or Doc().tagtext()
 
     def table():
-        return tag('table', klass='table table-bordered')
+        return tag('table', klass='table table-bordered table-sm')
     def tr():
         return tag('tr')
-    def td():
-        return tag('td')
+    def td_key():
+        return tag('td', klass='td-key')
+    def td_value():
+        return tag('td', klass='td-value')
 
     with table():
         for key, value in input_dict.items():
             with tr():
-                with td():
+                with td_key():
                     text(key)
-                with td():
+                with td_value():
                     if type(value) == list:
                         if any(type(i) == dict for i in value):
                             with table():
                                 for item in value:
                                     with tr():
-                                        with td():
+                                        with td_value():
                                             dict_as_html(item, (doc, tag, text))
                         else:
                             text(', '.join([str(i) for i in value]))

--- a/portal/render.py
+++ b/portal/render.py
@@ -10,10 +10,13 @@ def dict_as_html(input_dict, tagtext=None):
 
     def table():
         return tag('table', klass='table table-bordered table-sm')
+
     def tr():
         return tag('tr')
+
     def td_key():
         return tag('td', klass='td-key')
+
     def td_value():
         return tag('td', klass='td-value')
 

--- a/portal/routes.py
+++ b/portal/routes.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, abort
 
 from .api.client import ApiClient
-from .render import dict_as_html
+from .render import object_as_html
 
 
 blueprint = Blueprint('routes', __name__, template_folder='templates')
@@ -27,7 +27,7 @@ def details(type, id):
         abort(404)
     client = ApiClient('TODO: base url from config')
     details = client.get_entity(id)
-    details_html = dict_as_html(details)
+    details_html = object_as_html(details)
     return render_template('pages/details.html', type=type, id=id, details_html=details_html)
 
 

--- a/portal/static/table.css
+++ b/portal/static/table.css
@@ -1,0 +1,13 @@
+table .td-key
+{
+  width:auto;
+  text-align:right;
+  white-space: nowrap
+}
+table .td-value {
+  width: 100%
+}
+table .table {
+  margin-bottom: 0;
+
+}

--- a/portal/static/todo-styles.css
+++ b/portal/static/todo-styles.css
@@ -1,21 +1,9 @@
 .no-content {
   background-color: pink;
-  border: 4px solid;
-  border-image: repeating-linear-gradient(
-    -45deg,
-    pink, pink 1px,
-    white 1px, white 2px
-  ) 4;
 }
 
 .fill-content {
   background-color: lightgrey;
-  border: 4px solid;
-  border-image: repeating-linear-gradient(
-    -45deg,
-    lightgrey, lightgrey 1px,
-    white 1px, white 2px
-  ) 4;
 }
 
 .no-format {
@@ -25,7 +13,6 @@
     pink, pink 1px,
     white 1px, white 2px
   ) 4;
-  background-color: white;
 }
 
 .fill-format {
@@ -35,5 +22,4 @@
     lightgrey, lightgrey 1px,
     white 1px, white 2px
   ) 4;
-  background-color: white;
 }

--- a/portal/templates/pages/base.html
+++ b/portal/templates/pages/base.html
@@ -15,24 +15,26 @@
   <body>
     {% include 'fragments/banner-top.html' %}
 
-    <header class="no-content">
-      {% block header %}{% endblock %}
-    </header>
+    <div class="container-fluid">
+      <header class="no-content">
+        {% block header %}{% endblock %}
+      </header>
 
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <section class="no-content">
-          <ul>
-            {% for message in messages %}
-              <li>{{ message }}</li>
-            {% endfor %}
-          </ul>
-        </section>
-      {% endif %}
-    {% endwith %}
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <section class="no-content">
+            <ul>
+              {% for message in messages %}
+                <li>{{ message }}</li>
+              {% endfor %}
+            </ul>
+          </section>
+        {% endif %}
+      {% endwith %}
 
-    <section>
-      {% block content %}{% endblock %}
-    </section>
+      <section>
+        {% block content %}{% endblock %}
+      </section>
+    </div>
   </body>
 </html>

--- a/portal/templates/pages/base.html
+++ b/portal/templates/pages/base.html
@@ -31,7 +31,7 @@
       {% endif %}
     {% endwith %}
 
-    <section class="no-content">
+    <section>
       {% block content %}{% endblock %}
     </section>
   </body>

--- a/portal/templates/pages/base.html
+++ b/portal/templates/pages/base.html
@@ -16,25 +16,29 @@
     {% include 'fragments/banner-top.html' %}
 
     <div class="container-fluid">
-      <header class="no-content">
-        {% block header %}{% endblock %}
-      </header>
+      <div class="row">
+        <div class="col">
+          <header class="no-content">
+            {% block header %}{% endblock %}
+          </header>
 
-      {% with messages = get_flashed_messages() %}
-        {% if messages %}
-          <section class="no-content">
-            <ul>
-              {% for message in messages %}
-                <li>{{ message }}</li>
-              {% endfor %}
-            </ul>
+          {% with messages = get_flashed_messages() %}
+            {% if messages %}
+              <section class="no-content">
+                <ul>
+                  {% for message in messages %}
+                    <li>{{ message }}</li>
+                  {% endfor %}
+                </ul>
+              </section>
+            {% endif %}
+          {% endwith %}
+
+          <section>
+            {% block content %}{% endblock %}
           </section>
-        {% endif %}
-      {% endwith %}
-
-      <section>
-        {% block content %}{% endblock %}
-      </section>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/portal/templates/pages/base.html
+++ b/portal/templates/pages/base.html
@@ -19,7 +19,7 @@
     <div class="container-fluid">
       <div class="row">
         <div class="col">
-          <header class="no-content">
+          <header class="no-content no-format">
             {% block header %}{% endblock %}
           </header>
 

--- a/portal/templates/pages/base.html
+++ b/portal/templates/pages/base.html
@@ -8,6 +8,7 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='todo-styles.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='table.css') }}">
 
     <title>{% block title %}{% endblock %} | HuBMAP</title>
   </head>

--- a/portal/templates/pages/browse.html
+++ b/portal/templates/pages/browse.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="no-content">
+<div class="no-content no-format">
 TODO: Browse content: {{ type }}
 </div>
 {% endblock %}

--- a/portal/templates/pages/browse.html
+++ b/portal/templates/pages/browse.html
@@ -5,5 +5,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="no-content">
 TODO: Browse content: {{ type }}
+</div>
 {% endblock %}

--- a/portal/templates/pages/details.html
+++ b/portal/templates/pages/details.html
@@ -5,5 +5,7 @@
 {% endblock %}
 
 {% block content %}
-{{ details_html|safe }}
+<div class="no-content">
+  {{ details_html|safe }}
+</div>
 {% endblock %}

--- a/portal/templates/pages/details.html
+++ b/portal/templates/pages/details.html
@@ -5,5 +5,5 @@
 {% endblock %}
 
 {% block content %}
-TODO: Details content: {{ type }}, {{ id }}, {{ details_html|safe }}
+{{ details_html|safe }}
 {% endblock %}

--- a/portal/templates/pages/index.html
+++ b/portal/templates/pages/index.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="no-content">
+<div class="no-content no-format">
   <p>TODO: Home content</p>
   <p><a href="/browse/sample/asdf">Mock details page</a>
 </div>

--- a/portal/templates/pages/index.html
+++ b/portal/templates/pages/index.html
@@ -5,6 +5,8 @@
 {% endblock %}
 
 {% block content %}
-<p>TODO: Home content</p>
-<p><a href="/browse/sample/asdf">Mock details page</a>
+<div class="no-content">
+  <p>TODO: Home content</p>
+  <p><a href="/browse/sample/asdf">Mock details page</a>
+</div>
 {% endblock %}

--- a/portal/test_render.py
+++ b/portal/test_render.py
@@ -37,6 +37,14 @@ io_pairs = [
     </td>
   </tr>
 </table>
+'''),
+    ({'a': [1, {'X', 'Y'}]}, '''
+<table>
+  <tr>
+    <td>a</td>
+    <td>1, {'Y', 'X'}</td>
+  </tr>
+</table>
 ''')
 ]
 

--- a/portal/test_render.py
+++ b/portal/test_render.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from yattag import indent
 
@@ -41,5 +43,7 @@ io_pairs = [
 
 @pytest.mark.parametrize('io_pair', io_pairs)
 def test_dict_as_html(io_pair):
-    (input, output) = io_pair
-    assert indent(dict_as_html(input)) == output.strip()
+    (input_dict, expected_output_html) = io_pair
+    # CSS classes make output harder to read, obscure the structural issues which are the focus.
+    no_class_html = re.sub(r'\s*class="[^"]*"\s*', '', dict_as_html(input_dict))
+    assert indent(no_class_html) == expected_output_html.strip()

--- a/portal/test_render.py
+++ b/portal/test_render.py
@@ -3,7 +3,7 @@ import re
 import pytest
 from yattag import indent
 
-from .render import dict_as_html
+from .render import object_as_html
 
 
 io_pairs = [
@@ -15,7 +15,7 @@ io_pairs = [
   </tr>
 </table>
 '''),
-    ({'a': [1, 2]}, '''
+    ({'a': ['1', '2']}, '''
 <table>
   <tr>
     <td>a</td>
@@ -38,11 +38,27 @@ io_pairs = [
   </tr>
 </table>
 '''),
-    ({'a': [1, {'X', 'Y'}]}, '''
+    ({'a': [1, {'X': 'Y'}]}, '''
 <table>
   <tr>
     <td>a</td>
-    <td>1, {'Y', 'X'}</td>
+    <td>
+      <table>
+        <tr>
+          <td>1</td>
+        </tr>
+        <tr>
+          <td>
+            <table>
+              <tr>
+                <td>X</td>
+                <td>Y</td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
   </tr>
 </table>
 ''')
@@ -50,8 +66,8 @@ io_pairs = [
 
 
 @pytest.mark.parametrize('io_pair', io_pairs)
-def test_dict_as_html(io_pair):
-    (input_dict, expected_output_html) = io_pair
+def test_object_as_html(io_pair):
+    (input_object, expected_output_html) = io_pair
     # CSS classes make output harder to read, obscure the structural issues which are the focus.
-    no_class_html = re.sub(r'\s*class="[^"]*"\s*', '', dict_as_html(input_dict))
+    no_class_html = re.sub(r'\s*class="[^"]*"\s*', '', object_as_html(input_object))
     assert indent(no_class_html) == expected_output_html.strip()


### PR DESCRIPTION
Apply bootstrap styles to details table, handle more edgecase input structures, and make the todo-styles more consistent.

I will go ahead and merge this, but post merge critique welcome.

<img width="444" alt="Screen Shot 2019-10-16 at 3 03 42 PM" src="https://user-images.githubusercontent.com/730388/66950503-80182400-f026-11e9-8f40-9eeb882258a4.png">
